### PR TITLE
Build notebook in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,13 @@ jobs:
     #       org.opencontainers.image.version=${{ steps.prep.outputs.version }}
     #       org.opencontainers.image.revision=${{ github.sha }}
     #       org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
-    - name: Set image README on Docker Hub
-      if: steps.prep.outputs.push == 'true'
-      uses: peter-evans/dockerhub-description@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        repository: ${{ env.docker_repository }}
+    # - name: Update Docker Hub repository description
+    #   if: steps.prep.outputs.push == 'true'
+    #   uses: peter-evans/dockerhub-description@v2
+    #   with:
+    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+    #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    #     repository: ${{ env.docker_repository }}
     - name: Prepare and export .env
       if: steps.prep.outputs.push == 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,21 +92,21 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: Dockerfile
-        platforms: linux/amd64
-        push: ${{ steps.prep.outputs.push }}
-        tags: ${{ steps.prep.outputs.tags }}
-        labels: |
-          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-          org.opencontainers.image.source=${{ github.repositoryUrl }}
-          org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+    # - name: Build and push
+    #   id: docker_build
+    #   uses: docker/build-push-action@v2
+    #   with:
+    #     context: .
+    #     file: Dockerfile
+    #     platforms: linux/amd64
+    #     push: ${{ steps.prep.outputs.push }}
+    #     tags: ${{ steps.prep.outputs.tags }}
+    #     labels: |
+    #       org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+    #       org.opencontainers.image.source=${{ github.repositoryUrl }}
+    #       org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+    #       org.opencontainers.image.revision=${{ github.sha }}
+    #       org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
     - name: Set image README on Docker Hub
       if: steps.prep.outputs.push == 'true'
       uses: peter-evans/dockerhub-description@v2
@@ -115,7 +115,6 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
         repository: ${{ env.docker_repository }}
     - name: Prepare and export .env
-      if: steps.prep.outputs.push == 'true'
       run: |
         cp .env.example .env
         printf "%s\n" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,4 +130,4 @@ jobs:
       with:
         args: render /github/workspace/notebooks/examples/synapse.Rmd
     - name: List HTML notebooks
-      run: ls -al notebooks/*.html
+      run: ls -al notebooks/examples/*.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,6 @@ jobs:
     - name: Generate HTML notebooks
       uses: docker://tschaffter/rstudio:latest  # use sha256
       with:
-        args: render /github/workspace/notebooks/examples/synapse.Rmd
+        args: sudo render /github/workspace/notebooks/examples/synapse.Rmd
     - name: List HTML notebooks
       run: ls -al notebooks/*.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
 
 env:
   docker_repository: tschaffter/rstudio
+  # github.event.repository.clone_url not available for on: schedule
+  clone_url: https://github.com/tschaffter/rstudio.git
+  # github.event.repository.default_branch not available for on: schedule
+  default_branch: main
 
 jobs:
   lint:
@@ -65,6 +69,7 @@ jobs:
           fi
         elif [[ $GITHUB_REF == refs/pull/* ]]; then
           VERSION=pr-${{ github.event.number }}
+          PUSH=true
         fi
         TAGS="${DOCKER_IMAGE}:${VERSION}"
         if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
@@ -114,9 +119,8 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
         repository: ${{ env.docker_repository }}
-    - name: Run id
-      run: id
     - name: Prepare and export .env
+      if: steps.prep.outputs.push == 'true'
       run: |
         cp .env.example .env
         printf "%s\n" \
@@ -126,8 +130,54 @@ jobs:
           "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
         grep -v '^#' .env >> $GITHUB_ENV
     - name: Generate HTML notebooks
+      if: steps.prep.outputs.push == 'true'
       uses: docker://tschaffter/rstudio:edge  # use sha256
       with:
         args: render /github/workspace/notebooks/examples/synapse.Rmd
-    - name: List HTML notebooks
-      run: ls -al notebooks/examples/*.html
+    - name: Publish HTML notebooks to GH Pages
+      if: steps.prep.outputs.push == 'true'
+      run: |
+        git clone ${{ env.clone_url }} \
+          --branch gh-pages --single-branch gh-pages
+
+        # Update gh-pages: version specified
+        NOTEBOOKS_TARGET_DIR=gh-pages/${{ steps.prep.outputs.version }}/notebooks
+        rm -fr ${NOTEBOOKS_TARGET_DIR}
+        mkdir -p ${NOTEBOOKS_TARGET_DIR}
+        cp -R notebooks/examples/*.html ${NOTEBOOKS_TARGET_DIR}
+
+        # Update gh-pages: latest, major, and minor versions
+        if [ ! -z "${{ steps.prep.outputs.version_major }}" ]; then
+          # Update latest (e.g. "1.2.3" => "latest")
+          NOTEBOOKS_TARGET_DIR=gh-pages/latest/notebooks
+          rm -fr ${NOTEBOOKS_TARGET_DIR}
+          mkdir -p ${NOTEBOOKS_TARGET_DIR}
+          cp -R notebooks/examples/*.html ${NOTEBOOKS_TARGET_DIR}
+
+          # Update major version (e.g. "1.2.3" => "1")
+          NOTEBOOKS_TARGET_DIR=gh-pages/${{ steps.prep.outputs.version_major }}/notebooks
+          rm -fr ${NOTEBOOKS_TARGET_DIR}
+          mkdir -p ${NOTEBOOKS_TARGET_DIR}
+          cp -R notebooks/examples/*.html ${NOTEBOOKS_TARGET_DIR}
+
+          # Update minor version (e.g. "1.2.3" => "1.2")
+          NOTEBOOKS_TARGET_DIR=gh-pages/${{ steps.prep.outputs.version_minor }}/notebooks
+          rm -fr ${NOTEBOOKS_TARGET_DIR}
+          mkdir -p ${NOTEBOOKS_TARGET_DIR}
+          cp -R notebooks/examples/*.html ${NOTEBOOKS_TARGET_DIR}
+        fi
+        cd gh-pages
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Update notebooks" -a || true
+        # The above command will fail if no changes were present, so we ignore
+        # that.
+    - name: Push changes
+      if: steps.prep.outputs.push == 'true'
+      uses: ad-m/github-push-action@master
+      with:
+        branch: gh-pages
+        directory: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        force: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
         repository: ${{ env.docker_repository }}
+    - name: Run id
+      run: id
     - name: Prepare and export .env
       run: |
         cp .env.example .env
@@ -122,7 +124,7 @@ jobs:
           "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
         grep -v '^#' .env >> $GITHUB_ENV
     - name: Generate HTML notebooks
-      uses: docker://tschaffter/rstudio:latest
+      uses: docker://tschaffter/rstudio:latest  # use sha256
       with:
         args: render /github/workspace/notebooks/examples/synapse.Rmd
     - name: List HTML notebooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,13 @@ jobs:
         cp .env.example .env
         printf "%s\n" \
           "PASSWORD=${{ secrets.RSTUDIO_PASSWORD }}" \
-          "ROOT=TRUE" \
+          "USERID=$(id -u)" \
+          "GROUPID=$(id -g)" \
           "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
         grep -v '^#' .env >> $GITHUB_ENV
     - name: Generate HTML notebooks
       uses: docker://tschaffter/rstudio:latest  # use sha256
       with:
-        args: sudo render /github/workspace/notebooks/examples/synapse.Rmd
+        args: render /github/workspace/notebooks/examples/synapse.Rmd
     - name: List HTML notebooks
       run: ls -al notebooks/*.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   schedule:
-    - cron: '0 10 * * *' # everyday at 10am
+    - cron: '0 10 * * 0'  # every Sunday at 10am
   push:
     branches:
       - main
@@ -40,12 +40,12 @@ jobs:
     - name: Validate docker-compose.yml
       run: docker-compose -f docker-compose.yml config >/dev/null
 
-  docker:
+  build-and-publish:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare
+    - name: Prepare build
       id: prep
       run: |
         DOCKER_IMAGE=${{ env.docker_repository }}
@@ -86,7 +86,7 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
+    - name: Login to Docker Hub
       if: ${{ steps.prep.outputs.push }}
       uses: docker/login-action@v1
       with:
@@ -107,10 +107,24 @@ jobs:
           org.opencontainers.image.version=${{ steps.prep.outputs.version }}
           org.opencontainers.image.revision=${{ github.sha }}
           org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
-    # - name: Docker Hub Description
-    #   if: steps.prep.outputs.push == 'true'
-    #   uses: peter-evans/dockerhub-description@v2
-    #   with:
-    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-    #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    #     repository: ${{ env.docker_repository }}
+    - name: Set image README on Docker Hub
+      if: steps.prep.outputs.push == 'true'
+      uses: peter-evans/dockerhub-description@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        repository: ${{ env.docker_repository }}
+    - name: Prepare and export .env
+      if: steps.prep.outputs.push == 'true'
+      run: |
+        cp .env.example .env
+        printf "%s\n" \
+          "PASSWORD=${{ secrets.RSTUDIO_PASSWORD }}" \
+          "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
+        grep -v '^#' .env >> $GITHUB_ENV
+    - name: Generate HTML notebooks
+      uses: docker://tschaffter/rstudio:latest
+      with:
+        args: render /github/workspace/notebooks/examples/synapse.Rmd
+    - name: List HTML notebooks
+      run: ls -al notebooks/*.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,7 @@ jobs:
         cp .env.example .env
         printf "%s\n" \
           "PASSWORD=${{ secrets.RSTUDIO_PASSWORD }}" \
-          "USERID=$(id -u)" \
-          "GROUPID=$(id -g)" \
+          "ROOT=TRUE" \
           "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
         grep -v '^#' .env >> $GITHUB_ENV
     - name: Generate HTML notebooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: Prepare build
       id: prep
       run: |
@@ -56,7 +57,7 @@ jobs:
         VERSION=noop
         PUSH=false
         if [ "${{ github.event_name }}" = "schedule" ]; then
-          VERSION=nightly
+          VERSION=weekly
           PUSH=true
         elif [[ $GITHUB_REF == refs/tags/* ]]; then
           # VERSION=${GITHUB_REF#refs/tags/}
@@ -87,11 +88,14 @@ jobs:
         echo ::set-output name=tags::${TAGS}
         echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
         echo ::set-output name=push::${PUSH}
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
+
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
+
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:
@@ -106,37 +110,20 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push
-      id: docker_build
+    - name: Build image
       uses: docker/build-push-action@v2
       with:
         context: .
         file: Dockerfile
         builder: ${{ steps.buildx.outputs.name }}
         load: true
-        push: false  # ${{ steps.prep.outputs.push }}
+        push: false
         platforms: linux/amd64
         tags: rstudio-cached:latest
-        # tags: ${{ steps.prep.outputs.tags }}
-        # labels: |
-        #   org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-        #   org.opencontainers.image.source=${{ github.repositoryUrl }}
-        #   org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-        #   org.opencontainers.image.revision=${{ github.sha }}
-        #   org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
-    # - name: Update Docker Hub repository description
-    #   if: steps.prep.outputs.push == 'true'
-    #   uses: peter-evans/dockerhub-description@v2
-    #   with:
-    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-    #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    #     repository: ${{ env.docker_repository }}
-    # - name: Image digest
-    #   run: echo ${{ steps.docker_build.outputs.digest }}
-    - name: Prepare and export .env
-      if: steps.prep.outputs.push == 'true'
+
+    - name: Create .env
       run: |
         cp .env.example .env
         printf "%s\n" \
@@ -144,7 +131,6 @@ jobs:
           "USERID=$(id -u)" \
           "GROUPID=$(id -g)" \
           "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
-        grep -v '^#' .env >> $GITHUB_ENV
 
     - name: Generate HTML notebooks
       run: |
@@ -152,15 +138,37 @@ jobs:
           --env-file .env \
           -v $(pwd)/notebooks:/data \
           rstudio-cached:latest \
-          render /data/examples/notebook.Rmd
+          render /data/examples/synapse.Rmd
 
-    # - name: Generate HTML notebooks
+    - name: Push image
+      if: steps.prep.outputs.push == 'true'
+      id: docker_push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile
+        builder: ${{ steps.buildx.outputs.name }}
+        push: true
+        platforms: linux/amd64
+        tags: ${{ steps.prep.outputs.tags }}
+        labels: |
+          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+          org.opencontainers.image.source=${{ github.repositoryUrl }}
+          org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+    # - name: Update Docker Hub repository description
     #   if: steps.prep.outputs.push == 'true'
-    #   uses: docker://tschaffter/rstudio:edge  # use sha256
+    #   uses: peter-evans/dockerhub-description@v2
     #   with:
-    #     args: render /github/workspace/notebooks/examples/synapse.Rmd
+    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+    #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    #     repository: ${{ env.docker_repository }}
 
-    - name: Publish HTML notebooks to GH Pages
+    - name: Prepare to publish HTML notebooks to GH Pages
       if: steps.prep.outputs.push == 'true'
       run: |
         git clone ${{ env.clone_url }} \
@@ -199,7 +207,8 @@ jobs:
         git commit -m "Update notebooks" -a || true
         # The above command will fail if no changes were present, so we ignore
         # that.
-    - name: Push changes
+
+    - name: Push to gh-pages
       if: steps.prep.outputs.push == 'true'
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,14 @@ jobs:
         load: true
         push: false  # ${{ steps.prep.outputs.push }}
         platforms: linux/amd64
-        tags: ${{ steps.prep.outputs.tags }}
-        labels: |
-          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-          org.opencontainers.image.source=${{ github.repositoryUrl }}
-          org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+        tags: rstudio-cached:latest
+        # tags: ${{ steps.prep.outputs.tags }}
+        # labels: |
+        #   org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+        #   org.opencontainers.image.source=${{ github.repositoryUrl }}
+        #   org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+        #   org.opencontainers.image.revision=${{ github.sha }}
+        #   org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
     # - name: Update Docker Hub repository description
@@ -150,7 +151,7 @@ jobs:
         docker run --rm \
           --env-file .env \
           -v $(pwd)/notebooks:/data \
-          tschaffter/rstudio \
+          rstudio-cached:latest \
           render /data/examples/notebook.Rmd
 
     # - name: Generate HTML notebooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
         cp .env.example .env
         printf "%s\n" \
           "PASSWORD=${{ secrets.RSTUDIO_PASSWORD }}" \
+          "USERID=$(id -u)" \
+          "GROUPID=$(id -g)" \
           "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
         grep -v '^#' .env >> $GITHUB_ENV
     - name: Generate HTML notebooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
         grep -v '^#' .env >> $GITHUB_ENV
     - name: Generate HTML notebooks
-      uses: docker://tschaffter/rstudio:latest  # use sha256
+      uses: docker://tschaffter/rstudio:edge  # use sha256
       with:
         args: render /github/workspace/notebooks/examples/synapse.Rmd
     - name: List HTML notebooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,28 +90,41 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
+      id: buildx
       uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-single-buildx
+
     - name: Login to Docker Hub
-      if: ${{ steps.prep.outputs.push }}
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    # - name: Build and push
-    #   id: docker_build
-    #   uses: docker/build-push-action@v2
-    #   with:
-    #     context: .
-    #     file: Dockerfile
-    #     platforms: linux/amd64
-    #     push: ${{ steps.prep.outputs.push }}
-    #     tags: ${{ steps.prep.outputs.tags }}
-    #     labels: |
-    #       org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-    #       org.opencontainers.image.source=${{ github.repositoryUrl }}
-    #       org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-    #       org.opencontainers.image.revision=${{ github.sha }}
-    #       org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile
+        builder: ${{ steps.buildx.outputs.name }}
+        load: true
+        push: false  # ${{ steps.prep.outputs.push }}
+        platforms: linux/amd64
+        tags: ${{ steps.prep.outputs.tags }}
+        labels: |
+          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+          org.opencontainers.image.source=${{ github.repositoryUrl }}
+          org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
     # - name: Update Docker Hub repository description
     #   if: steps.prep.outputs.push == 'true'
     #   uses: peter-evans/dockerhub-description@v2
@@ -119,6 +132,8 @@ jobs:
     #     username: ${{ secrets.DOCKERHUB_USERNAME }}
     #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
     #     repository: ${{ env.docker_repository }}
+    # - name: Image digest
+    #   run: echo ${{ steps.docker_build.outputs.digest }}
     - name: Prepare and export .env
       if: steps.prep.outputs.push == 'true'
       run: |
@@ -129,11 +144,21 @@ jobs:
           "GROUPID=$(id -g)" \
           "SYNAPSE_TOKEN=${{ secrets.SYNAPSE_TOKEN }}" | tee -a .env >/dev/null
         grep -v '^#' .env >> $GITHUB_ENV
+
     - name: Generate HTML notebooks
-      if: steps.prep.outputs.push == 'true'
-      uses: docker://tschaffter/rstudio:edge  # use sha256
-      with:
-        args: render /github/workspace/notebooks/examples/synapse.Rmd
+      run: |
+        docker run --rm \
+          --env-file .env \
+          -v $(pwd)/notebooks:/data \
+          tschaffter/rstudio \
+          render /data/examples/notebook.Rmd
+
+    # - name: Generate HTML notebooks
+    #   if: steps.prep.outputs.push == 'true'
+    #   uses: docker://tschaffter/rstudio:edge  # use sha256
+    #   with:
+    #     args: render /github/workspace/notebooks/examples/synapse.Rmd
+
     - name: Publish HTML notebooks to GH Pages
       if: steps.prep.outputs.push == 'true'
       run: |

--- a/notebooks/examples/synapse.Rmd
+++ b/notebooks/examples/synapse.Rmd
@@ -12,10 +12,14 @@ output:
     toc: yes
 ---
 
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
 # Requirements
 
 Set the value of `SYNAPSE_TOKEN` in the configuration file `.env` to one of your
-Synapse personal access tokens. Token can be generated in Synpase via your User
+Synapse personal access tokens. Token can be generated in Synapse via your User
 Menu > Settings > Persona Access Tokens.
 
 # Conda environments
@@ -35,7 +39,7 @@ Activate the environment `sage-bionetworks`.
 use_condaenv("sage-bionetworks", required = TRUE)
 ```
 
-# Loging into your Synapse account
+# Logging into your Synapse account
 
 ```{r}
 # Prepare Synapse Python Client
@@ -49,5 +53,5 @@ syn <- synapseclient$Synapse()
 syn$login()
 ```
 
-Upon successful logging, the message "Welcome, <your name>!" should be displayed
+Upon successful logging, the message "Welcome, your name!" should be displayed
 above.


### PR DESCRIPTION
Fixes #51 

### Notes

- Optimized CI workflow that build and cache the image, generate the notebook and then if successful, publish the docker image and notebooks to GH Pages.
- Render only one notebook for now. All the notebooks will be rendered in another PR.