### PR TITLE
Release 1.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         cp .env.example .env
         export $(grep -v '^#' .env | xargs -d '\n')
     - name: Validate docker-compose.yml
-      run: docker compose -f docker-compose.yml config >/dev/null
+      run: docker-compose -f docker-compose.yml config >/dev/null
 
   build-and-publish:
     needs: [test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         cp .env.example .env
         export $(grep -v '^#' .env | xargs -d '\n')
     - name: Validate docker-compose.yml
-      run: docker-compose -f docker-compose.yml config >/dev/null
+      run: docker compose -f docker-compose.yml config >/dev/null
 
   build-and-publish:
     needs: [test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         context: .
         file: Dockerfile
         builder: ${{ steps.buildx.outputs.name }}
-        load: true
+        # load: true
         push: false
         platforms: linux/amd64,linux/arm64
         tags: rstudio-cached:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         builder: ${{ steps.buildx.outputs.name }}
         load: true
         push: false
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         tags: rstudio-cached:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
@@ -157,7 +157,7 @@ jobs:
         file: Dockerfile
         builder: ${{ steps.buildx.outputs.name }}
         push: true
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.prep.outputs.tags }}
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,9 +124,9 @@ jobs:
         context: .
         file: Dockerfile
         builder: ${{ steps.buildx.outputs.name }}
-        # load: true
+        load: true
         push: false
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         tags: rstudio-cached:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Features:
 - Benefit from regular updates of the image [tschaffter/rstudio] which will
   bring the latest versions of R/RStudio and other dependencies (Miniconda, R
   and Python packages).
+- You only need the Docker Engine on your system to develop code in R and Python
+  (see [Requirements](#requirements)).
 
 This image includes the following common Sage Bionetworks software:
 
@@ -48,7 +50,6 @@ All packages:
 ### Requirements
 
 - [Docker Engine] >=19.03.0
-- [Docker Compose] >=1.27.0
 
 ## Example notebooks
 
@@ -76,13 +77,13 @@ Rmd Notebook | Description | HTML Notebook
 
 2. Start RStudio. Add the option `-d` or `--detach` to run in the background.
 
-       docker-compose up
+       docker compose up
 
 RStudio is now available at http://localhost. On the login page, enter the
 default username (`rstudio`) and the password specified in `.env`.
 
-To stop RStudio, enter `Ctrl+C` followed by `docker-compose down`.  If running
-in detached mode, you will only need to enter `docker-compose down`.
+To stop RStudio, enter `Ctrl+C` followed by `docker compose down`.  If running
+in detached mode, you will only need to enter `docker compose down`.
 
 ## How to use this repository
 
@@ -197,7 +198,7 @@ docker run --rm \
     --env-file .env \
     -v $(pwd)/notebooks:/data \
     tschaffter/rstudio:4.0.5 \
-    render /data/examples/notebook.Rmd
+    render /data/examples/*.Rmd
 ```
 
 ## Versioning


### PR DESCRIPTION
- Replace `docker-compose` by `docker compose` (no longer need to install Docker Compose)
- Build image for arm64